### PR TITLE
New _Controller class and separate _PubSubMixin

### DIFF
--- a/src/js/rishson/control/Controller.js
+++ b/src/js/rishson/control/Controller.js
@@ -1,20 +1,20 @@
 define([
     "rishson/Globals",
-    "rishson/control/_ControllerMixin",
+    "rishson/control/_Controller",
     "rishson/util/ObjectValidator",
     "dojo/_base/lang", // mixin, hitch
     "dojo/_base/array", // indexOf, forEach
     "dojo/_base/declare", // declare
     "dojo/topic", // publish/subscribe
     "dojox/rpc/Service"
-], function(Globals, _ControllerMixin, ObjectValidator, lang, arrayUtil, declare, topic, Service){
+], function(Globals, _Controller, ObjectValidator, lang, arrayUtil, declare, topic, Service){
 
     /**
      * @class
      * @name rishson.control.Controller
      * @description This class is the conduit for all client server communication.
      */
-    return declare('rishson.control.Controller', [_ControllerMixin], {
+    return declare('rishson.control.Controller', [_Controller], {
     
         /**
          * @field

--- a/src/js/rishson/control/MockTransport.js
+++ b/src/js/rishson/control/MockTransport.js
@@ -26,7 +26,7 @@ define([
          */
         requestTimeout : 5000,  //defaults to 5 seconds
 
-    	/**
+		/**
 		 * @field
 		 * @name rishson.control.MockTransport.namespace
 		 * @type {String}

--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -1,0 +1,109 @@
+define([
+    "rishson/control/_PubSubMixin",
+    "dojo/_base/declare", // declare
+    "dojo/_base/array", // forEach
+    "dojo/_base/lang", // hitch
+    "dojo/topic" // publish/subscribe
+], function (_PubSubMixin, declare, arrayUtil, lang, topic) {
+    /**
+     * @class
+     * @name rishson.control._Controller
+     * @description This is a mixin for Controller classes/widgets<p>
+     * Controllers are classes that wire together the view (widgets) and the model.<p>
+     * Application widgets are basically 'Controllers' in an MVC paradigm. Application widgets typically provide layout<p>
+     * container functionality to child widgets and act as the controller for the enclosed child widgets.<p>
+     * An Application widget knows about all views (child widgets) and models (stores) for the 'Application'.<p>
+     * This class specifically adds the autowiring of topics between child widgets and the Application widget.<p>
+     *<p>
+     * Usage:<p>
+     *<p>
+     * myChildWidget.pubList({SOME_EVENT :'some/topic'});<p>
+     * ...<p>
+     * myApplicationWidget.injectWidget(myChildWidget);<p>
+     * or
+     * myController.adopt(myChildWIdget, {}, someDomNode);<p>
+     *<p>
+     * At this point, all the topic in mychildWidget.pubList are wired to event handlers in myApplicationWidget.
+     */
+    return declare("rishson.control._Controller", _PubSubMixin, {
+
+		/**
+		 * @constructor
+		 */
+		constructor : function (args) {
+			this._topicNamespace = this.createTopicNamespace(this.declaredClass);
+			this.pubList = {};
+			this.subList = {};
+		},
+
+        /**
+         * @function
+         * @name rishson.control._ControllerMixin.injectWidget
+         * @param {rishson.widget._Widget} widget a widget to examine for topics
+         * @description widgets injected into this class will be examined to autowire its publish and subscribes.<p>
+         * This function should be called for declarativly created widgets.
+         */
+        injectWidget : function (widget) {
+            this._autowirePubs(widget);
+        },
+    
+        /**
+         * @function
+         * @name rishson.control._ControllerMixin.adopt
+         * @override rishson.widget._WidgetInWidgetMixin.adopt
+         * @description widgets injected into this class will be examined to autowire its publish and subscribes.<p>
+         * This function should be called for programatically created widgets.
+         */
+        adopt : function (/*Function*/cls, /*Object*/props, /*DomNode*/node) {
+            var widget = new cls(props, node);
+            this._autowirePubs(widget);
+            return widget;
+        },
+
+    
+        /**
+         * @function
+         * @name rishson.control._ControllerMixin._autowirePubs
+         * @private
+         * @param {rishson.widget._Widget} widget a widget that contains a pubList of topics that it can publish.
+         * @description autowire the published topics from the widget to event handlers in the Application widget.
+         */
+        _autowirePubs : function (widget) {
+            //iterate over each published topic of the passed in widget - the application widget need to subscribe to these		
+    
+            for(var topicObj in widget.pubList) {
+                if(widget.pubList.hasOwnProperty(topicObj)) {
+                    var topicName = widget.pubList[topicObj];
+                    //capitalise the topic section names and remove slashes
+                    var handlerFuncName = this._capitaliseTopicName(topicName);
+                    handlerFuncName = '_handle' + handlerFuncName.replace(/[//]/g, '');
+
+                    //the implementing class needs to have _handle[topicName] functions by convention
+                    var handlerFunc = this[handlerFuncName];
+                    if(handlerFunc) {
+                        topic.subscribe(topicName, lang.hitch(this, handlerFunc));
+                    }
+                    else {
+                        console.error('Autowire failure for topic: ' + topicName + '. No handler: ' + handlerFuncName);
+                    }    
+                }	
+            }
+        },
+    
+        /**
+         * @function
+         * @name rishson.control._ControllerMixin._capitaliseTopicName
+         * @private
+         * @param {String} topic a name of a topic to capitalise.
+         * @description capitalise the first letter of a topic.
+         */
+        _capitaliseTopicName : function (topic) {
+            /* e.g. /hello/i/am/a/topicName would become Hello/I/Am/A/TopicName
+            */
+            return topic.replace(/\b[a-z]/g, function (w) {
+                return w.toUpperCase();
+            });
+        }
+    
+    });
+});

--- a/src/js/rishson/control/_PubSubMixin.js
+++ b/src/js/rishson/control/_PubSubMixin.js
@@ -1,0 +1,73 @@
+define([
+	"rishson/Globals",	//TOPIC_NAMESPACE
+	"dojo/_base/declare"	// declare
+], function (Globals, declare) {
+
+	/**
+	 * @class
+	 * @name rishson.widget.WidgetInWidgetMixin
+	 * @description This is a class based version of Phil Higgin's awesome solution to memory leaks that can occur
+	 * when creating widgets programatically inside custom widgets<p>
+	 * Please see <a href='http://higginsforpresident.net/2010/01/widgets-within-widgets/'>here.</a>
+	 */
+	return declare('rishson.control._PubSubMixin', null, {
+
+		/**
+		 * @field
+		 * @name rishson.widget._Widget._globalTopicNamespace
+		 * @type {String}
+		 * @private
+		 * @description This namespace is prepended to every topic name used by a derived widget
+		 */
+		_globalTopicNamespace : Globals.TOPIC_NAMESPACE,
+
+		/**
+		 * @field
+		 * @name rishson.widget._Widget._topicNamespace
+		 * @type {string}
+		 * @private
+		 * @description This namespace is prepended to every topic name used by a derived widget
+		 */
+		_topicNamespace : '',
+
+		/**
+		 * @field
+		 * @name rishson.widget._Widget.pubList
+		 * @type {Object}
+		 * @description Object that contains the list of topics that any derived widget can publish
+		 */
+		pubList : null,
+
+		/**
+		 * @field
+		 * @name rishson.widget._Widget.subList
+		 * @type {Object}
+		 * @description Object that contains the list of topics that any derived widget can listen out for
+		 */
+		subList : null,
+
+		createTopicNamespace : function (cls) {
+			/*any derived widget can publish events on their own namespace so construct the widget namespace from
+			 the declared class, but replace the . to be a / so it is standard topic conventions*/
+			return '/' + cls.replace(/\./g, '/');
+		},
+
+		/**
+		 * @function
+		 * @name rishson.widget._Widget.addTopic
+		 * @param topicRef {String} the object property (usually CAPITALISED) of the topic in the pubList
+		 * @param topicName {String} the name of topic
+		 * @param makeGlobal {Boolean} optional if true use the global topic namespace
+		 * @description Syntaatic sugar to add items to a widgets pubList.
+		 */
+		addTopic : function (topicRef, topicName, makeGlobal) {
+			if (!makeGlobal) {
+				this.pubList[topicRef] = this._topicNamespace + topicName;
+			}
+			else {
+				this.pubList[topicRef] = this._globalTopicNamespace + topicName;
+			}
+		}
+
+	});
+});

--- a/src/js/rishson/tests/data/restResponses/RestResponse.js
+++ b/src/js/rishson/tests/data/restResponses/RestResponse.js
@@ -1,11 +1,11 @@
 define([
-    "dojo/_base/declare",
-    "dojo/_base/lang"
+	"dojo/_base/declare",
+	"dojo/_base/lang"
 ], function(declare, lang){
-    return declare(null, {
-        constructor : function(params, ioArgs) {
-            lang.mixin(this, params);
-            this.ioArgs = ioArgs || {xhr : {status : 200}};
-        }
-    });
+	return declare(null, {
+		constructor : function(params, ioArgs) {
+			lang.mixin(this, params);
+			this.ioArgs = ioArgs || {xhr : {status : 200}};
+		}
+	});
 });

--- a/src/js/rishson/widget/_Widget.js
+++ b/src/js/rishson/widget/_Widget.js
@@ -1,11 +1,11 @@
 define([
     "dijit/_Widget",    //mixin
     "rishson/widget/_WidgetInWidgetMixin",  //mixin
-    "rishson/Globals",
+	"rishson/control/_PubSubMixin",  //mixin
     "dojo/_base/declare", // declare
-    "dojo/_base/lang", // hitch mixin
+    "dojo/_base/lang", // hitch
     "dojo/topic" // publish/subscribe
-], function(_Widget, _WidgetInWidgetMixin, Globals, declare, lang, topic){
+], function (_Widget, _WidgetInWidgetMixin, _PubSubMixin, declare, lang, topic) {
     /**
      * @class
      * @name rishson.widget._Widget
@@ -14,33 +14,8 @@ define([
      * This base class also adds very generic event pub/sub abilities so that widgets can be completely self-contained and
      * not have to know about their runtime invocation container or understand context concerns such as Ajax request.
      */
-    return declare("rishson.widget._Widget", [_Widget, _WidgetInWidgetMixin], {
-    
-        /**
-         * @field
-         * @name rishson.widget._Widget._globalTopicNamespace
-         * @type {String}
-         * @private
-         * @description This namespace is prepended to every topic name used by a derived widget
-         */
-        _globalTopicNamespace : Globals.TOPIC_NAMESPACE,
-    
-        /**
-         * @field
-         * @name rishson.widget._Widget.pubList
-         * @type {Object}
-         * @description Object that contains the list of topics that any derived widget can publish
-         */
-        pubList : null,
-    
-        /**
-         * @field
-         * @name rishson.widget._Widget.subList
-         * @type {Object}
-         * @description Object that contains the list of topics that any derived widget can listen out for
-         */
-        subList : null,
-    
+    return declare("rishson.widget._Widget", [_Widget, _WidgetInWidgetMixin, _PubSubMixin], {
+
         /**
          * @field
          * @name rishson.widget._Widget.isInitialised
@@ -61,17 +36,18 @@ define([
         /**
          * @constructor
          */
-         constructor : function() {
-            /*create a unique id for every instance of a widget. This is needed for when we publish our events and want to
+		constructor : function () {
+			/*create a unique id for every instance of a widget. This is needed for when we publish our events and want to
               publish who we are. If id is blank then we assume there is only 1 instance of the implementing widget.*/
             this._widgetId = this.declaredClass + this.id;
-            
-            /*any derived widget can publish events on their own namespace so construct the widget namespace from
-            the declared class, but replace the . to be a / so it is standard topic conventions*/
-            this._topicNamespace = '/' + this.declaredClass.replace(/\./g, '/');
+
+            this._topicNamespace = this.createTopicNamespace(this.declaredClass);
         
-            this.pubList = {WIDGET_INITIALISED : this._globalTopicNamespace + '/initialised'};
-            this.subList = {WIDGET_DISABLE : this._globalTopicNamespace + '/disable',
+            this.pubList = {
+				WIDGET_INITIALISED : this._globalTopicNamespace + '/initialised'
+			};
+            this.subList = {
+				WIDGET_DISABLE : this._globalTopicNamespace + '/disable',
                 WIDGET_ENABLE : this._globalTopicNamespace + '/enable',
                 ERROR_CME : this._globalTopicNamespace + '/error/cme',
                 ERROR_INVALID : this._globalTopicNamespace + '/error/invalid'
@@ -89,40 +65,14 @@ define([
             topic.subscribe(this.subList.WIDGET_ENABLE, lang.hitch(this, "_enable"));
             topic.subscribe(this.subList.ERROR_CME, lang.hitch(this, "_cmeHandler"));
             topic.subscribe(this.subList.ERROR_INVALID, lang.hitch(this, "_invalidHandler"));
-    
-            var indexOfClassName = this.declaredClass.lastIndexOf('.') + 1;
-            var className = this.declaredClass.slice(indexOfClassName);
-    
-            /* FIXME: this won't work async.  Should probably pull in resources per-widget.
-            dojo.requireLocalization("rishson.enterprise", className);
-            this._nlsStrings = i18n.getLocalization("rishson.enterprise", className);
-            */
-    
+
             this.inherited(arguments);  //dijit._Widget
         },
 
         /**
          * @function
-         * @name rishson.widget._Widget.addTopic
-         * @param topicRef {String} the object property (usually CAPITALISED) of the topic in the pubList
-         * @param topicName {String} the name of topic
-         * @param makeGlobal {Boolean} optional if true use the global topic namespace
-         * @description Syntaatic sugar to add items to a widgets pubList.
-         */
-        addTopic : function(topicRef, topicName, makeGlobal) {
-            if(!makeGlobal){
-                this.pubList[topicRef] = this._topicNamespace + topicName;
-            }
-            else {
-                this.pubList[topicRef] = this._globalTopicNamespace + topicName;
-            }
-        },
-
-
-        /**
-         * @function
          * @private
-         * @description When the derrived is ready then it can call this function to publish their state
+         * @description When the derived is ready then it can call this function to publish their state
          */
         _initialised : function () {
             this.isInitialised = true;

--- a/src/js/rishson/widget/_WidgetInWidgetMixin.js
+++ b/src/js/rishson/widget/_WidgetInWidgetMixin.js
@@ -1,7 +1,8 @@
 define([
+	"rishson/Globals",	//TOPIC_NAMESPACE
     "dojo/_base/declare", // declare
     "dojo/_base/array" // forEach, indexOf
-], function(declare, arrayUtil){
+], function (Globals, declare, arrayUtil) {
     /**
      * @class
      * @name rishson.widget.WidgetInWidgetMixin
@@ -10,7 +11,7 @@ define([
      * Please see <a href='http://higginsforpresident.net/2010/01/widgets-within-widgets/'>here.</a>
      */
     return declare('rishson.widget._WidgetInWidgetMixin', null, {
-    
+
         /**
          * @function
          * @name rishson.widget._WidgetInWidget.adopt
@@ -64,7 +65,6 @@ define([
             }
             destroy && this.__kill(widget);
         },
-    
         //private functions-------------------------------------------------------------------------------------------------
     
         /**


### PR DESCRIPTION
In trying to orphan the SearchController, _Controller was also missing the orphan and __kill methods. I haven't put those into this pull request - not sure if it is as simple as using this._supportingWidgets as that was being added to by adopt on _WidgetInWidgetMixin.
