### PR TITLE
Removed initialise topic and reference to loading groups

### DIFF
--- a/src/js/rishson/Base.js
+++ b/src/js/rishson/Base.js
@@ -15,14 +15,6 @@ define([
 	return declare('rishson.Base', null, {
 		/**
 		 * @field
-		 * @name rishson.Base.isInitialised
-		 * @type {boolean}
-		 * @description Is the widget initialised? Default to false - duh.
-		 */
-		isInitialised: false,
-
-		/**
-		 * @field
 		 * @name rishson.Base._parentTopicNamespace
 		 * @type {string}
 		 * @description This namespace is prepended to every topic name used by a derived class

--- a/src/js/rishson/Base.js
+++ b/src/js/rishson/Base.js
@@ -65,8 +65,6 @@ define([
 				if (!this._supportingWidgets) {
 					this._supportingWidgets = [];	//anything that does not derive from _Widget will not have this
 				}
-
-				this.addTopic('INITIALISED', Globals.CHILD_INTIALISED_TOPIC_NAME);
 			}
 		},
 
@@ -195,16 +193,6 @@ define([
 					//ignore errors thrown by IE when doing teardown of Grids whose domNode's get removed early
 				}
 			}
-		},
-
-		/**
-		 * @function
-		 * @private
-		 * @description When the derived is ready then it can call this function to publish their state
-		 */
-		_initialise: function () {
-			this.isInitialised = true;
-			topic.publish(this.pubList.INITIALISED, this._id, this);
 		}
 	});
 });

--- a/src/js/rishson/Base.js
+++ b/src/js/rishson/Base.js
@@ -118,13 +118,15 @@ define([
 		 * If the requiring widget is a controller (inherits from rishson.control._Controller) then it will also
 		 * autowire the widget.
 		 * @param {Object} widget
+		 * @param {Object=} props
+		 * @param {Object=} node
 		 * @return {Object} deferred
 		 */
-		asyncRequire: function (widget) {
+		asyncRequire: function (widget, props, node) {
 			var deferred = new Deferred();
 
 			require([widget], lang.hitch(this, function (WidgetConstructor) {
-				var widgetInstance = this.adopt(WidgetConstructor, {});
+				var widgetInstance = this.adopt(WidgetConstructor, props, node);
 				deferred.resolve(widgetInstance);
 			}));
 			return deferred;

--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -61,10 +61,6 @@ define([
 
 			this.subList = this.subList || {};
 
-			// Add event listener for child widget initialisation events.
-			// Must be done before child adoption/creation otherwise this class cannot listen to child's published events.
-			this._wireSinglePub(this._topicNamespace + Globals.CHILD_INTIALISED_TOPIC_NAME, true);
-
 			this.views = {};
 			this.loadingGroups = {
 				toLoad: [],
@@ -118,13 +114,8 @@ define([
 		 * @param {string} topicName the string of the topic name
 		 * @description autowire a single published topic from the child widget to an event handler on the controller widget.
 		 */
-		_wireSinglePub: function (topicName, initialWire) {
+		_wireSinglePub: function (topicName) {
 			var handlerFuncName, handlerFunc;
-
-			// If event to wire is child initialised skip wiring as this was already wired in constructor.
-			if (!initialWire && topicName.indexOf(Globals.CHILD_INTIALISED_TOPIC_NAME) !== -1) {
-				return;
-			}
 
 			handlerFuncName = this._createHandlerFuncName(topicName);
 
@@ -180,10 +171,6 @@ define([
 				obj = scope.views[args.name] = this.adopt(args.widget, args.props, args.node);
 				if (group && typeof i !== 'undefined') {
 					group.toLoad[i] = obj;
-				}
-
-				if (!obj.isInitialised) {
-					obj._initialise();
 				}
 			}
 		},

--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -140,42 +140,6 @@ define([
 		},
 
 		/**
-		 * @name rishson.control._Controller.loadGroup
-		 * @description Take a loadGroup, loop over each widget and create and add that widget to the controller.
-		 * @param {Object} scope the scope of the current controller. Assignment needs to occur before initialisation
-		 * @param {Array} group
-		 */
-		loadGroup: function (scope, group) {
-			var i, l;
-			for (i = 0, l = group.toLoad.length; i < l; i += 1) {
-				this.addAndInitialise(scope, group.toLoad[i], group, i);
-			}
-		},
-
-		/**
-		 *
-		 * @function
-		 * @name rishson.control._Controller.addAndInitialise
-		 * @description adopted widgets from controllers should fire their initialised event after they have been assigned at
-		 * to the controller assignee
-		 * @param {Object} scope the scope of the current controller. Assignment needs to occur before initialisation
-		 * @param {{name: string, widget: string, loadingGroup: Array, props: Object, node: string|Object}} args The
-		 * initialisation properties for the widget to be included on the page.
-		 * @param {Array} group
-		 * @param {number} i
-		 */
-		addAndInitialise: function (scope, args, group, i) {
-			var obj;
-
-			if (scope && args.name && args.widget) {
-				obj = scope.views[args.name] = this.adopt(args.widget, args.props, args.node);
-				if (group && typeof i !== 'undefined') {
-					group.toLoad[i] = obj;
-				}
-			}
-		},
-
-		/**
 		 * @function
 		 * @name rishson.control._Controller.adopt
 		 * @description widgets injected into this class will be examined to autowire its publish and subscribes.<p>
@@ -199,35 +163,6 @@ define([
 
 			this._autowirePubs(child);
 			return child;
-		},
-
-		/**
-		 * @function
-		 * @name rishson.control._Controller.checkLoadingGroups
-		 * @description Compare the id of the widget which is just initialised with the loading groups array, and move
-		 * from toLoad to loaded if found. Attach the widgets to the layout if all of them have been loaded.
-		 * TODO: smarter 'loadingGroups' logic needs to be created so that there can be more than one loadingGroup array
-		 * and faster indexing.
-		 * @param {string} id
-		 */
-		checkLoadingGroups: function (id) {
-			var i,
-				l,
-				match = false;
-
-			//if all widgets that I care about have been initialised then I should attach them and publish my initialise to my parent
-			for (i = 0, l = this.loadingGroups.toLoad.length; i < l; i += 1) {
-				if (this.loadingGroups.toLoad[i] && this.loadingGroups.toLoad[i]._id === id) {
-					this.loadingGroups.loaded[i] = this.loadingGroups.toLoad[i];
-					delete this.loadingGroups.toLoad[i];
-					match = true;
-					break;
-				}
-			}
-
-			if (match && this.loadingGroups.loaded.length === this.loadingGroups.toLoad.length) {
-				this.attachWidgetsToLayout(this.loadingGroups.loaded);
-			}
 		},
 
 		/**

--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -36,22 +36,6 @@ define([
 		_topicNamespace: '',
 
 		/**
-		 * @field
-		 * @name rishson._Controller.views
-		 * @type {Object}
-		 * @description A key store of the child views (widgets and controllers) of this controller.
-		 */
-		views: null,
-
-		/**
-		 * @field
-		 * @name rishson._Controller.loadingGroups
-		 * @type {{toLoad: Array, loaded: Array}}
-		 * @description A key store of the child views (widgets and controllers) of this controller.
-		 */
-		loadingGroups: null,
-
-		/**
 		 * @constructor
 		 */
 		constructor: function () {


### PR DESCRIPTION
Removed autowiring and reference to initialise. there is no need to call _initialised on a widget over and above its standard dojo lifecycle.

Removed the extraneous code for loading groups, use asyncRequire instead.
