### PR TITLE
Recursively un-autowire and destroy all widgets upon orphaning a widget

### DIFF
--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -44,6 +44,10 @@ define([
 			this._id = this.declaredClass;
 
 			this.subList = this.subList || {};
+
+			// An array of topic name / subscription handle pairs
+			// Needed for when the controller wants to unsubscribe from topics
+			this.subListHandles = this.subListHandles || {};
 		},
 
 		/**
@@ -104,8 +108,10 @@ define([
 
 			//the implementing class needs to have _handle[topicName] functions by convention
 			handlerFunc = this[handlerFuncName];
+
 			if (handlerFuncName && handlerFunc) {
-				this.subscribe(topicName, lang.hitch(this, handlerFunc));
+				// Subscribe to topic and keep a reference to the handle for unsubscribing
+				this.subListHandles[topicName] = this.subscribe(topicName, lang.hitch(this, handlerFunc));
 			} else {
 				console.error('Autowire failure for topic: ' + topicName + '. No handler: ' + handlerFuncName);
 			}


### PR DESCRIPTION
Changes to _Controller
- The controller now keeps a hash of handles and topic names when this.subscribe is called

Changes to ControllerWidget
- Helper methods addView and addModel now decorate the objects with their types, similarly upon creating a controller, it decorates itself with the controller type. This is used to determine the type of object during teardown.

Changes to Base
- orphan no longer calls dojo's destroyRecursive
- orphan now calls its destroyDescendants method to ensure that orphan is subsequently called on all of its children
- Within orphan, if the caller is a controller then  _unAutoWirePubs is called to remove any subscriptions from the widget it is orphaning
- orphan checks whether the widget is already being destroyed before progressing. This fixes the issue where orphan is called multiple times on a widget
