### PR TITLE
Added lang.defer function and fixed orphan to override destroyDescendants

### DIFF
--- a/src/js/rishson/Base.js
+++ b/src/js/rishson/Base.js
@@ -190,10 +190,12 @@ define([
 							this._unAutoWirePubs(widget);
 						}
 
-						// We call rishson.Base.destroyDescendants first to ensure that orphan is called
-						// on all children, this ensures a proper recursive tear-down is performed
-						widget.destroyDescendants();
-						widget.destroy();
+						// Destroy the widget
+						if (widget.destroyRecursive) {
+							widget.destroyRecursive();
+						} else if (widget.destroy) {
+							widget.destroy();
+						}
 					}
 				} catch (e) {
 					//ignore errors thrown by IE when doing teardown of Grids whose domNode's get removed early
@@ -204,11 +206,10 @@ define([
 		/**
 		 * @function
 		 * @name rishson.Base.destroyDescendants
-		 * @description Calls orphan on any children of the widget
+		 * @description Override for dijit._WidgetBase.destroyDescendants to orphan all supporting
+		 * widgets and children for objects that inherit from rishon.Base
 		 **/
 		destroyDescendants: function () {
-			this._beingDestroyed = true;
-
 			// Determine children to orphan
 			var children = rishsonLang.unionArrays(this._supportingWidgets, this.getChildren());
 

--- a/src/js/rishson/Base.js
+++ b/src/js/rishson/Base.js
@@ -183,7 +183,7 @@ define([
 
 			if (destroy) {
 				try {
-					if (widget && widget.destroyRecursive) {
+					if (widget) {
 						// If this is a controller we need to un-auto-wire any subscriptions
 						// to this widget
 						if (this._unAutoWirePubs && lang.isFunction(this._unAutoWirePubs)) {

--- a/src/js/rishson/base/lang.js
+++ b/src/js/rishson/base/lang.js
@@ -53,9 +53,23 @@ define([], function () {
 			}
 		},
 
+		/**
+		 * @function
+		 * @name rishson.Base.lang.defer
+		 * @description Defers a function, scheduling it to run after the current call stack has cleared
+		 * @param {Function} func The function to be called
+		 * @param {Object} scope Optional scope for the function to be called within
+		 **/
+		defer = function (func, scope) {
+			return setTimeout(function () {
+				return func.apply(scope);
+			}, 0);
+		},
+
 		lang = {
 			unionArrays: unionArrays,
-			forEachObjProperty: forEachObjProperty
+			forEachObjProperty: forEachObjProperty,
+			defer: defer
 		};
 
 	return lang;

--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -87,7 +87,6 @@ define([
 
 					// If a handle was found then remove the subscription
 					if (handle) {
-						console.log("Unautowiring: " + pubHandleName);
 						this.unsubscribe(handle);
 						delete this.subListHandles[pubHandleName];
 					}

--- a/src/js/rishson/control/_Controller.js
+++ b/src/js/rishson/control/_Controller.js
@@ -87,6 +87,7 @@ define([
 
 					// If a handle was found then remove the subscription
 					if (handle) {
+						console.log("Unautowiring: " + pubHandleName);
 						this.unsubscribe(handle);
 						delete this.subListHandles[pubHandleName];
 					}

--- a/src/js/rishson/widget/_Widget.js
+++ b/src/js/rishson/widget/_Widget.js
@@ -10,7 +10,7 @@ define([
 	 * @class
 	 * @name rishson.widget._Widget
 	 * @description This is the base class for all widgets.<p>
-	 * We mixin Phil Higgin's memory leak mitigation solution that is implemented in _WidgetInWidgetMixin.<p>
+	 * We mixin Phil Higgin's memory leak mitigation solution that is implemented in Base.<p>
 	 * This base class also adds very generic event pub/sub abilities so that widgets can be completely self-contained and
 	 * not have to know about their runtime invocation container or understand context concerns such as Ajax request.
 	 */


### PR DESCRIPTION
Fixes to orphan
- Some dijit widgets override destroyRecursive to provide their own logic and this would have not been called prior to this update.
- destroyRecursive calls destroyDescendants internally so it makes sense to override the destroyDescendants method for widgets that inherit from Rishon.base.
- This update is very similar to Phil Higgins memory leak solution

Defer function
- Executes a function after the current call-stack has cleared
- We're using it a couple of times within ri-app for resizing layouts so it makes sense to create a helper

Misc
- Tested with ri-app & Indium
