### PR TITLE
Updates to MockTransport and control/Response

### DIFF
--- a/src/js/rishson/control/MockTransport.js
+++ b/src/js/rishson/control/MockTransport.js
@@ -84,7 +84,8 @@ define([
 				testMethodClass,
 				methodParams,
 				mockResponse,
-				wrappedResponse;
+				wrappedResponse,
+				queryString;
 
 			//if an app is specified in the send, then get the application specific url
 			if (appId) {
@@ -95,6 +96,11 @@ define([
 				namespace += 'serviceResponses/' + request.toUrl();
 			} else if (request.declaredClass === 'rishson.control.RestRequest') {
 				namespace += 'restResponses/' + request.toUrl() + '/' + request.verb;
+				if (namespace.indexOf("?") !== -1) {
+					namespace = namespace.split("?");
+					queryString = namespace[1].split("/");
+					namespace = namespace[0] + "/" + queryString[1] + "?" + queryString[0];
+				}
 			} else {
 				throw ('Unknown request type supplied: ' + request.declaredClass);
 			}

--- a/src/js/rishson/control/MockTransport.js
+++ b/src/js/rishson/control/MockTransport.js
@@ -99,7 +99,8 @@ define([
 				if (namespace.indexOf("?") !== -1) {
 					namespace = namespace.split("?");
 					queryString = namespace[1].split("/");
-					namespace = namespace[0] + "/" + queryString[1] + "?" + queryString[0];
+					// Use an underscore instead of a question mark for OS that cannot support it.
+					namespace = namespace[0] + "/" + queryString[1] + "_" + queryString[0];
 				}
 			} else {
 				throw ('Unknown request type supplied: ' + request.declaredClass);

--- a/src/js/rishson/control/Response.js
+++ b/src/js/rishson/control/Response.js
@@ -71,7 +71,7 @@ define([
 		 * @type {Array.<number>}
 		 * @description The status codes that are handled in a rishson.control.Response.
 		 */
-		mappedStatusCodes: [200, 400, 403, 404, 409, 500],
+		mappedStatusCodes: [200, 400, 403, 409, 500],
 
 		/**
 		 * @constructor
@@ -111,8 +111,6 @@ define([
 				break;
 			case 403:
 				this.isUnauthorised = true;
-				break;
-			case 404:
 				break;
 			case 409:
 				this.isConflicted = true;

--- a/src/js/rishson/control/Response.js
+++ b/src/js/rishson/control/Response.js
@@ -71,7 +71,7 @@ define([
 		 * @type {Array.<number>}
 		 * @description The status codes that are handled in a rishson.control.Response.
 		 */
-		mappedStatusCodes: [200, 400, 403, 409],
+		mappedStatusCodes: [200, 400, 403, 404, 409, 500],
 
 		/**
 		 * @constructor
@@ -111,6 +111,8 @@ define([
 				break;
 			case 403:
 				this.isUnauthorised = true;
+				break;
+			case 404:
 				break;
 			case 409:
 				this.isConflicted = true;

--- a/src/js/rishson/control/Response.js
+++ b/src/js/rishson/control/Response.js
@@ -50,6 +50,14 @@ define([
 
 		/**
 		 * @field
+		 * @name rishson.control.Request.isServerError
+		 * @type {boolean}
+		 * @description is the response indicating that the request was a server error. This equates to HTTP status code 500.
+		 */
+		isServerError: false,
+
+		/**
+		 * @field
 		 * @name rishson.control.Request.payload
 		 * @type {object}
 		 * @description the contents of the server response.
@@ -106,6 +114,9 @@ define([
 				break;
 			case 409:
 				this.isConflicted = true;
+				break;
+			case 500:
+				this.isServerError = true;
 				break;
 			default:
 				throw ('Unknown status code passed to Response constructor: ' + ioArgs.xhr.status);


### PR DESCRIPTION
- Added isServerError and 500 code to Rishson Response handler
- Mocktransport checks for querystring parameters and reconstructs the static file URL to /yourEndpoint/Get_somequerystring=test.js
